### PR TITLE
Remove package dependency on json

### DIFF
--- a/nixos-options.el
+++ b/nixos-options.el
@@ -9,7 +9,7 @@
 ;; Keywords: unix
 ;; Homepage: http://www.github.com/travisbhartwell/nix-emacs/
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "24") (json "1.4"))
+;; Package-Requires: ((emacs "24"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
json 1.4 is not installable separately from Emacs; the `(emacs "24")` dependency suffices here.

(In connection with https://github.com/milkypostman/melpa/pull/2954/files)