### PR TITLE
Fix error if nixos option file is not found

### DIFF
--- a/nixos-options.el
+++ b/nixos-options.el
@@ -95,9 +95,11 @@ Returns VALUE unchanged if not a boolean."
       `(,name . ,data))))
 
 (defvar nixos-options
-  (let* ((json-key-type 'string)
-         (raw-options (json-read-file nixos-options-json-file)))
-    (mapcar 'nixos-options--make-alist raw-options)))
+  (if (file-exists-p nixos-options-json-file)
+      (let* ((json-key-type 'string)
+             (raw-options (json-read-file nixos-options-json-file)))
+        (mapcar 'nixos-options--make-alist raw-options))
+    (message "Warning: Cannot find nixos option file.")))
 
 (defun nixos-options-get-documentation-for-option (option)
   (concat (nixos-options-display-name option)


### PR DESCRIPTION
Hi Travis,

This PR fixes an error if nixos option file is not found. A warning message is displayed in this case.
I did not test the fix further than starting spacemacs on a non NixOS system so maybe the package will error afterwards when being effectively used (nix-options is set to nil if the file is not found).

Cheers,
syl20bnr