### PR TITLE
Simplest possible fix for #12

### DIFF
--- a/nixos-options.el
+++ b/nixos-options.el
@@ -66,7 +66,7 @@
 
 (defvar nixos-options-json-file
   (let* ((cmd
-           "nix-build -Q --no-out-link '<nixpkgs/nixos/release.nix>' -A options")
+           "nix-build -Q --no-out-link '<nixpkgs/nixos/release.nix>' -A options 2>/dev/null")
           (dir (replace-regexp-in-string "\n\\'" ""
                                          (shell-command-to-string cmd))))
     (expand-file-name "share/doc/nixos/options.json" dir))


### PR DESCRIPTION
The warnings are on stderr, the data we want is on stdout, just redirect
stderr to /dev/null.  While it is perhaps not the prettiest ever
solution, it is simple and effective.