### PR TITLE
Add autoload cookie for helm-nixos-options

### DIFF
--- a/helm-nixos-options.el
+++ b/helm-nixos-options.el
@@ -38,6 +38,7 @@
                ("Pretty print" . (lambda (f) (message "Pretty Printed: %s" (pp f))))
                ("Display name" . (lambda (f) (message "Name: %s" (nixos-options-get-name f))))))))
 
+;;;###autoload
 (defun helm-nixos-options ()
   (interactive)
   (helm :sources `(,(helm-source-nixos-options-search))


### PR DESCRIPTION
Adds the missing autoload cookie to `helm-nixos-options`.