### PR TITLE
Bugfix: backend was taking over completion in all modes

### DIFF
--- a/company-nixos-options.el
+++ b/company-nixos-options.el
@@ -49,10 +49,16 @@
       (buffer-substring (point) (save-excursion (skip-syntax-backward "w_.")
                                                 (point))))
 
+(defun company-nixos--in-nix-context-p ()
+  (or (eq major-mode 'nix-mode)
+      (equal "nix" (file-name-extension
+                    (buffer-file-name (current-buffer))))))
+
 (defun company-nixos-options--prefix ()
   "Grab prefix at point."
-  (or (company-nixos--grab-symbol)
-      'stop))
+  (and (company-nixos--in-nix-context-p)
+       (or (company-nixos--grab-symbol)
+           'stop)))
 
 ;;;###autoload
 (defun company-nixos-options (command &optional arg &rest ignored)


### PR DESCRIPTION
Previously when the company-nixos-options company backend was enabled, other backends for other modes were not getting a chance to run because this backend never returned nil to the 'prefix' command.  This caused this completion to be the only one that ever fired regardless of mode.  The below change checks whether we are in a mode called 'nix-mode' or whether the file extension is .nix and if neither is true, passes control to the next backend.  This should fix the issue.  