### PR TITLE
Use bash for shell command instead of sh

### DIFF
--- a/nix-sandbox.el
+++ b/nix-sandbox.el
@@ -58,7 +58,7 @@ e.g. /home/user/.nix-defexpr/channels/unstable/nixpkgs"
 ;;;###autoload
 (defun nix-shell-command (sandbox &rest args)
   "Assemble a command from ARGS that can be executed in the specified SANDBOX."
-  (list "sh" "-c" (format "source %s; %s" (nix-sandbox-rc sandbox) (s-join " " args))))
+  (list "bash" "-c" (format "source %s; %s" (nix-sandbox-rc sandbox) (s-join " " args))))
 
 (defun nix-shell-string (sandbox &rest args)
   "Assemble a command string from ARGS that can be executed in the specifed SANDBOX."


### PR DESCRIPTION
Sh may not have source and declare

It seemd that often bash and sh is the same binary, but not in case of
ubuntu 16.10, for example.