### PR TITLE
Fix broken detection of nix context

### DIFF
--- a/company-nixos-options.el
+++ b/company-nixos-options.el
@@ -50,9 +50,9 @@
                                                 (point))))
 
 (defun company-nixos--in-nix-context-p ()
-  (or (eq major-mode 'nix-mode)
-      (equal "nix" (file-name-extension
-                    (buffer-file-name (current-buffer))))))
+  (or (derived-mode-p 'nix-mode 'nix-repl-mode)
+      (let ((file-name (buffer-file-name (current-buffer))))
+        (and file-name (equal "nix" (file-name-extension file-name))))))
 
 (defun company-nixos-options--prefix ()
   "Grab prefix at point."


### PR DESCRIPTION
- Backend raised errors in non-nix-related buffers that were not associated with a file, e.g. `*scratch*`
- `derived-mode-p` is the correct way to test for the current major modes
- Also enable in nix-repl-mode