### PR TITLE
fix sandbox detection to exclude directories

### DIFF
--- a/nix-sandbox.el
+++ b/nix-sandbox.el
@@ -108,7 +108,11 @@ file is returned.  Otherwise if the directory contains a
               (sandbox-directory
                (funcall map-nil 'expand-file-name
                         (locate-dominating-file path
-                          '(lambda (dir) (directory-files dir t ".*\.nix$")))))
+                          '(lambda (dir)
+                             (seq-filter
+                              (lambda (candidate)
+                                (not (file-directory-p candidate)))
+                              (directory-files dir t ".*\\.nix$"))))))
               (shell-nix (and sandbox-directory (concat sandbox-directory "shell.nix"))))
          (if (and sandbox-directory (file-exists-p shell-nix))
              shell-nix


### PR DESCRIPTION
the previous detection of nix sandboxes was incorrectly considering
directories that ended in `-nix` as a sandbox directory (it was
searching for `.nix` without escaping the dot).

also, even fixing the regex, if one had a directory ending in
`.nix` (for example: `haskell.nix` for IOHK's repo), the parent
directory would be considered the sandbox directory.

therefore, here, we fix the regex to escape the dot and to also reject
directories that end in `.nix` from the search.

Examples:

The examples below use the following test structure:

```
ͳ pwd
/home/thales/tmp/test-nix-sandbox
ͳ tree
.
├── current-project
│   └── current.buffer
├── test-nix
│   └── some.file
└── test.nix
    └── some.file

3 directories, 3 files
```

Results of `(nix-current-sandbox)`
- Before the changes: `"/home/thales/tmp/test-nix-sandbox/"`
- Fixing just the regex without `test.nix` dir: `nil`
- Fixing just the regex: `"/home/thales/tmp/test-nix-sandbox/"`
- Rejecting directories: `nil`