### PR TITLE
Fix nix-executable-find

### DIFF
--- a/nix-sandbox.el
+++ b/nix-sandbox.el
@@ -95,8 +95,9 @@ e.g. /home/user/.nix-defexpr/channels/unstable/nixpkgs"
 ;;;###autoload
 (defun nix-executable-find (sandbox executable)
   "finds an EXECUTABLE in SANDBOX"
-  (set (make-local-variable 'exec-path) (nix-exec-path sandbox))
-  (executable-find executable))
+  (with-temp-buffer
+    (set (make-local-variable 'exec-path) (nix-exec-path sandbox))
+    (executable-find executable)))
 
 
 ;;;###autoload

--- a/nix-sandbox.el
+++ b/nix-sandbox.el
@@ -94,9 +94,10 @@ e.g. /home/user/.nix-defexpr/channels/unstable/nixpkgs"
 
 ;;;###autoload
 (defun nix-executable-find (sandbox executable)
-  "Search for an EXECUTABLE in the given SANDBOX."
-  (let ((exec-path (nix-exec-path sandbox)))
-    (and exec-path (executable-find executable))))
+  "finds an EXECUTABLE in SANDBOX"
+  (set (make-local-variable 'exec-path) (nix-exec-path sandbox))
+  (executable-find executable))
+
 
 ;;;###autoload
 (defun nix-find-sandbox (path)


### PR DESCRIPTION
I found that the former version of nix-executable-find didn't work. I've tested this one and it seems to work now